### PR TITLE
Using BOs of type BO_SHMEM instead of BO_CMD for kernarg memory region

### DIFF
--- a/rocrtst/suites/aie/aie_hsa_dispatch_test.cc
+++ b/rocrtst/suites/aie/aie_hsa_dispatch_test.cc
@@ -223,7 +223,7 @@ int main(int argc, char **argv) {
       num_data_elements * sizeof(std::uint32_t);
 
   std::uint32_t *input = {};
-  r = hsa_amd_memory_pool_allocate(global_dev_mem_pool, data_buffer_size, 0,
+  r = hsa_amd_memory_pool_allocate(global_kernarg_mem_pool, data_buffer_size, 0,
                                    reinterpret_cast<void **>(&input));
   assert(r == HSA_STATUS_SUCCESS);
   std::uint32_t input_handle = {};
@@ -232,7 +232,7 @@ int main(int argc, char **argv) {
   assert(input_handle != 0);
 
   std::uint32_t *output = {};
-  r = hsa_amd_memory_pool_allocate(global_dev_mem_pool, data_buffer_size, 0,
+  r = hsa_amd_memory_pool_allocate(global_kernarg_mem_pool, data_buffer_size, 0,
                                    reinterpret_cast<void **>(&output));
   assert(r == HSA_STATUS_SUCCESS);
   std::uint32_t output_handle = {};

--- a/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -147,7 +147,7 @@ XdnaDriver::AllocateMemory(const core::MemoryRegion &mem_region,
   }
 
   if (region.kernarg()) {
-    create_bo_args.type = AMDXDNA_BO_CMD;
+    create_bo_args.type = AMDXDNA_BO_SHMEM;
   } else {
     create_bo_args.type = AMDXDNA_BO_DEV;
   }


### PR DESCRIPTION
We were using BO_CMD for the kernarg memory region which is used for input and output data. The issue is that BO_CMDs cannot be pinned by the xdna driver (https://github.com/amd/xdna-driver/blob/main/src/driver/amdxdna/amdxdna_gem.c#L695-L705) and thus we cannot pass BO_CMDs as operands to commands. We should instead be using BO_SHMEM which can be pinned and also, unlike the dev memory region, is more flexible as it doesn't need to exist in the heap. 