### PR TITLE
`-DBUILD_SHARED_LIBS=ON` in CI

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -88,6 +88,7 @@ jobs:
           
           cmake -GNinja \
             -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=ON \
             -DCMAKE_INSTALL_PREFIX="$rocr_install_dir" \
             -DClang_DIR=$HOME/llvm/lib/cmake/clang \
             -DLLVM_DIR=$HOME/llvm/lib/cmake/llvm \


### PR DESCRIPTION
Fixes a breaking change introduced in https://github.com/nod-ai/ROCR-Runtime/commit/49a7483e98ace4f590d254b90de5ed9de9ad8cc6