### PR TITLE
Import/export for AIEs via vmem API

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -85,7 +85,7 @@ jobs:
           mkdir -p "$build_rocr_dir"
           build_rocr_dir="$(cd $build_rocr_dir && pwd)"
           rocr_install_dir="$GITHUB_WORKSPACE/rocr-install"
-          
+
           cmake -GNinja \
             -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_SHARED_LIBS=ON \
@@ -94,7 +94,7 @@ jobs:
             -DLLVM_DIR=$HOME/llvm/lib/cmake/llvm \
             -DIMAGE_SUPPORT=OFF \
             -S "$rocr_dir" -B "$build_rocr_dir"
-          
+
           cmake --build "$build_rocr_dir" --target install
           tar -cf rocr-${GITHUB_SHA::8}.tar rocr-install
 
@@ -138,7 +138,7 @@ jobs:
       - name: Build and run AIE smoke test
         run: |
           pushd rocrtst/suites/aie
-          
+
           build_dir="$PWD/build"
           mkdir -p $build_dir
           cmake -GNinja \
@@ -146,15 +146,15 @@ jobs:
             "-Dhsa-runtime64_DIR=$hsa_runtime64_ROOT/lib64/cmake/hsa-runtime64" \
             -S "$PWD" -B "$build_dir"
           cmake --build "$build_dir" --target aie_hsa_bare_add_one
-          
+
           "$build_dir"/aie_hsa_bare_add_one $PWD
-          
+
           popd
 
       - name: Build AIE test suite
         run: |
           pushd rocrtst/suites/aie
-          
+
           build_dir="$PWD/build"
           mkdir -p $build_dir
           cmake -GNinja \
@@ -162,9 +162,25 @@ jobs:
             "-Dhsa-runtime64_DIR=$hsa_runtime64_ROOT/lib64/cmake/hsa-runtime64" \
             -S "$PWD" -B "$build_dir"
           cmake --build "$build_dir" --target aie_hsa_dispatch_test
-          
+
           "$build_dir"/aie_hsa_dispatch_test $PWD
-          
+
+          popd
+
+      - name: Build AIE memory test suite
+        run: |
+          pushd rocrtst/suites/aie
+
+          build_dir="$PWD/build"
+          mkdir -p $build_dir
+          cmake -GNinja \
+            -DCMAKE_BUILD_TYPE=Release \
+            "-Dhsa-runtime64_DIR=$hsa_runtime64_ROOT/lib64/cmake/hsa-runtime64" \
+            -S "$PWD" -B "$build_dir"
+          cmake --build "$build_dir" --target memory
+
+          "$build_dir"/memory
+
           popd
 
   release:

--- a/rocrtst/suites/aie/CMakeLists.txt
+++ b/rocrtst/suites/aie/CMakeLists.txt
@@ -1,3 +1,12 @@
+include(FetchContent)
+
+FetchContent_Declare(
+  Catch2
+  GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+  GIT_TAG v3.5.4
+)
+FetchContent_MakeAvailable(Catch2)
+
 find_package(hsa-runtime64 CONFIG REQUIRED NAMES hsa_runtime64 hsa-runtime64)
 
 # smoke test
@@ -5,4 +14,26 @@ add_executable(aie_hsa_bare_add_one aie_hsa_bare_add_one.cc)
 
 # hsa test
 add_executable(aie_hsa_dispatch_test aie_hsa_dispatch_test.cc)
-target_link_libraries(aie_hsa_dispatch_test PUBLIC hsa-runtime64::hsa-runtime64)
+target_link_libraries(aie_hsa_dispatch_test PRIVATE hsa-runtime64::hsa-runtime64)
+
+# memory test
+add_executable(memory memory.cc)
+set_target_properties(memory
+  PROPERTIES
+    CXX_STANDARD                17
+    CXX_EXTENSIONS              OFF
+    CXX_VISIBILITY_PRESET       hidden
+    VISIBILITY_INLINES_HIDDEN   ON
+    POSITION_INDEPENDENT_CODE   ON
+)
+target_compile_options(memory
+  PRIVATE
+    -Wall
+    -Wextra
+    -Wpedantic
+)
+target_link_libraries(memory
+  PRIVATE
+    hsa-runtime64::hsa-runtime64
+    Catch2::Catch2WithMain
+)

--- a/rocrtst/suites/aie/memory.cc
+++ b/rocrtst/suites/aie/memory.cc
@@ -1,0 +1,274 @@
+/*
+ * =============================================================================
+ *   ROC Runtime Conformance Release License
+ * =============================================================================
+ * The University of Illinois/NCSA
+ * Open Source License (NCSA)
+ *
+ * Copyright (c) 2024, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Developed by:
+ *
+ *                 AMD Research and AMD ROC Software Development
+ *
+ *                 Advanced Micro Devices, Inc.
+ *
+ *                 www.amd.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal with the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimers.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimers in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the names of <Name of Development Group, Name of Institution>,
+ *    nor the names of its contributors may be used to endorse or promote
+ *    products derived from this Software without specific prior written
+ *    permission.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS WITH THE SOFTWARE.
+ *
+ */
+
+#include <vector>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "hsa/hsa.h"
+#include "hsa/hsa_ext_amd.h"
+
+namespace {
+
+template <hsa_device_type_t DeviceType>
+hsa_status_t discover_agents(hsa_agent_t agent, void *data)
+{
+  if (data == nullptr)
+  {
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  }
+
+  hsa_device_type_t device_type = {};
+  const auto ret = hsa_agent_get_info(agent, HSA_AGENT_INFO_DEVICE, &device_type);
+  if (ret != HSA_STATUS_SUCCESS)
+  {
+    return ret;
+  }
+
+  if (device_type == DeviceType)
+  {
+    auto *const agents = static_cast<std::vector<hsa_agent_t> *>(data);
+    agents->push_back(agent);
+  }
+
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t discover_first_global_coarse_grain_mem_pool(hsa_amd_memory_pool_t pool, void *data)
+{
+  if (!data)
+  {
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  }
+
+  hsa_amd_memory_pool_global_flag_t flags = {};
+  auto ret = hsa_amd_memory_pool_get_info(pool, HSA_AMD_MEMORY_POOL_INFO_GLOBAL_FLAGS, &flags);
+  if (ret != HSA_STATUS_SUCCESS)
+  {
+    return ret;
+  }
+
+  if ((flags & (HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_FINE_GRAINED |
+                HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_EXTENDED_SCOPE_FINE_GRAINED)) != 0x0)
+  {
+    auto *global_memory_pool = static_cast<hsa_amd_memory_pool_t *>(data);
+    *global_memory_pool = pool;
+    return HSA_STATUS_INFO_BREAK;
+  }
+
+  return HSA_STATUS_SUCCESS;
+}
+
+} // namespace
+
+TEST_CASE("Export global coarse-grain memory")
+{
+  REQUIRE(hsa_init() == HSA_STATUS_SUCCESS);
+
+  std::vector<hsa_agent_t> gpu_agents;
+  REQUIRE(hsa_iterate_agents(discover_agents<HSA_DEVICE_TYPE_GPU>, &gpu_agents) == HSA_STATUS_SUCCESS);
+  REQUIRE(!gpu_agents.empty());
+
+  std::vector<hsa_agent_t> aie_agents;
+  REQUIRE(hsa_iterate_agents(discover_agents<HSA_DEVICE_TYPE_AIE>, &aie_agents) == HSA_STATUS_SUCCESS);
+  REQUIRE(!aie_agents.empty());
+
+  hsa_amd_memory_pool_t global_memory_pool = {};
+  REQUIRE(hsa_amd_agent_iterate_memory_pools(gpu_agents.front(),
+                                             discover_first_global_coarse_grain_mem_pool,
+                                             &global_memory_pool) == HSA_STATUS_INFO_BREAK);
+  REQUIRE(global_memory_pool.handle != 0);
+
+  constexpr std::size_t buffer_size = 1024;
+  constexpr std::size_t allocation_size = buffer_size * sizeof(std::uint32_t);
+  std::uint32_t *buffer = {};
+  const std::uint32_t flags = 0;
+  REQUIRE(hsa_amd_memory_pool_allocate(global_memory_pool,
+                                       allocation_size,
+                                       flags,
+                                       reinterpret_cast<void **>(&buffer)) == HSA_STATUS_SUCCESS);
+  REQUIRE(buffer != nullptr);
+
+  for (std::size_t i = 0; i < buffer_size; ++i)
+  {
+    buffer[i] = i;
+  }
+
+  SECTION("hsa_amd_portable_export_dmabuf")
+  {
+    int dma_buf_fd = -1;
+    std::uint64_t dma_buf_offset = 0;
+    REQUIRE(hsa_amd_portable_export_dmabuf(buffer,
+                                           allocation_size,
+                                           &dma_buf_fd,
+                                           &dma_buf_offset) == HSA_STATUS_SUCCESS);
+    REQUIRE(dma_buf_fd > -1);
+
+    const std::uint32_t num_agents = 1;
+    auto *agent = &(aie_agents.front());
+    const std::uint32_t flags = 0;
+    std::size_t import_size = 0;
+    std::uint32_t *import_buffer = nullptr;
+    REQUIRE(hsa_amd_interop_map_buffer(num_agents, agent, dma_buf_fd, flags,
+                                       &import_size, reinterpret_cast<void **>(&import_buffer),
+                                       nullptr, nullptr) != HSA_STATUS_SUCCESS);
+
+    REQUIRE(hsa_amd_portable_close_dmabuf(dma_buf_fd) == HSA_STATUS_SUCCESS);
+  }
+
+  SECTION("hsa_amd_agents_allow_access")
+  {
+    REQUIRE(hsa_amd_agents_allow_access(aie_agents.size(),
+                                        aie_agents.data(),
+                                        nullptr,
+                                        buffer) != HSA_STATUS_SUCCESS);
+  }
+
+  REQUIRE(hsa_amd_memory_pool_free(buffer) == HSA_STATUS_SUCCESS);
+
+  REQUIRE(hsa_shut_down() == HSA_STATUS_SUCCESS);
+}
+
+TEST_CASE("Export host memory")
+{
+  REQUIRE(hsa_init() == HSA_STATUS_SUCCESS);
+
+  std::vector<hsa_agent_t> aie_agents;
+  REQUIRE(hsa_iterate_agents(discover_agents<HSA_DEVICE_TYPE_AIE>, &aie_agents) == HSA_STATUS_SUCCESS);
+  REQUIRE(!aie_agents.empty());
+
+  std::vector<void *> agent_ptrs(aie_agents.size());
+
+  constexpr std::size_t buffer_size = 1024;
+  constexpr std::size_t allocation_size = buffer_size * sizeof(std::uint32_t);
+  std::uint32_t *buffer = new std::uint32_t[buffer_size];
+  REQUIRE(buffer != nullptr);
+
+  for (std::size_t i = 0; i < buffer_size; ++i)
+  {
+    buffer[i] = i;
+  }
+
+  REQUIRE(hsa_amd_memory_lock(buffer,
+                              allocation_size,
+                              aie_agents.data(),
+                              aie_agents.size(),
+                              agent_ptrs.data()) != HSA_STATUS_SUCCESS);
+
+  delete[] buffer;
+
+  REQUIRE(hsa_shut_down() == HSA_STATUS_SUCCESS);
+}
+
+TEST_CASE("Vmem Set Access")
+{
+  REQUIRE(hsa_init() == HSA_STATUS_SUCCESS);
+
+  std::vector<hsa_agent_t> cpu_agents;
+  REQUIRE(hsa_iterate_agents(discover_agents<HSA_DEVICE_TYPE_CPU>, &cpu_agents) == HSA_STATUS_SUCCESS);
+  REQUIRE(!cpu_agents.empty());
+
+  std::vector<hsa_agent_t> gpu_agents;
+  REQUIRE(hsa_iterate_agents(discover_agents<HSA_DEVICE_TYPE_GPU>, &gpu_agents) == HSA_STATUS_SUCCESS);
+  REQUIRE(!gpu_agents.empty());
+
+  std::vector<hsa_agent_t> aie_agents;
+  REQUIRE(hsa_iterate_agents(discover_agents<HSA_DEVICE_TYPE_AIE>, &aie_agents) == HSA_STATUS_SUCCESS);
+  REQUIRE(!aie_agents.empty());
+
+  hsa_amd_memory_pool_t global_memory_pool = {};
+  REQUIRE(hsa_amd_agent_iterate_memory_pools(gpu_agents.front(),
+                                             discover_first_global_coarse_grain_mem_pool,
+                                             &global_memory_pool) == HSA_STATUS_INFO_BREAK);
+  REQUIRE(global_memory_pool.handle != 0);
+
+  const std::uint64_t flags = 0;
+
+  // allocate on GPU 0
+  constexpr std::size_t buffer_size = 1024;
+  constexpr std::size_t allocation_size = buffer_size * sizeof(std::uint32_t);
+  hsa_amd_vmem_alloc_handle_t memory_handle = {};
+  REQUIRE(hsa_amd_vmem_handle_create(global_memory_pool, allocation_size,
+                                     MEMORY_TYPE_PINNED, flags,
+                                     &memory_handle) == HSA_STATUS_SUCCESS);
+
+  // reserve on host
+  const std::uint64_t address = 0;
+  const std::uint64_t alignment = 0;
+  std::uint32_t *buffer = nullptr;
+  REQUIRE(hsa_amd_vmem_address_reserve_align(
+              reinterpret_cast<void **>(&buffer), allocation_size,
+              address, alignment, flags) == HSA_STATUS_SUCCESS);
+
+  const std::uint64_t offset = 0;
+  REQUIRE(hsa_amd_vmem_map(buffer, allocation_size, offset,
+                           memory_handle, flags) == HSA_STATUS_SUCCESS);
+
+  std::vector<hsa_amd_memory_access_desc_t> memory_access_desc;
+  memory_access_desc.reserve(cpu_agents.size() + gpu_agents.size() + aie_agents.size());
+  for (auto const &agent : cpu_agents)
+  {
+    memory_access_desc.push_back(hsa_amd_memory_access_desc_t{HSA_ACCESS_PERMISSION_RW, agent});
+  }
+  for (auto const &agent : gpu_agents)
+  {
+    memory_access_desc.push_back(hsa_amd_memory_access_desc_t{HSA_ACCESS_PERMISSION_RW, agent});
+  }
+  for (auto const &agent : aie_agents)
+  {
+    memory_access_desc.push_back(hsa_amd_memory_access_desc_t{HSA_ACCESS_PERMISSION_RW, agent});
+  }
+
+  REQUIRE(hsa_amd_vmem_set_access(buffer, allocation_size,
+                                  memory_access_desc.data(), memory_access_desc.size()) == HSA_STATUS_SUCCESS);
+
+  REQUIRE(hsa_amd_vmem_unmap(buffer, allocation_size) == HSA_STATUS_SUCCESS);
+
+  REQUIRE(hsa_amd_vmem_address_free(buffer, allocation_size) == HSA_STATUS_SUCCESS);
+
+  REQUIRE(hsa_amd_vmem_handle_release(memory_handle) == HSA_STATUS_SUCCESS);
+
+  REQUIRE(hsa_shut_down() == HSA_STATUS_SUCCESS);
+}

--- a/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -58,6 +58,10 @@
 namespace rocr {
 namespace AMD {
 
+static_assert((sizeof(core::ShareableHandle::handle) >= sizeof(uint32_t)) &&
+                  (alignof(core::ShareableHandle::handle) >= alignof(uint32_t)),
+              "ShareableHandle cannot store a XDNA handle");
+
 XdnaDriver::XdnaDriver(std::string devnode_name)
     : core::Driver(core::DriverType::XDNA, devnode_name) {}
 
@@ -286,22 +290,24 @@ hsa_status_t XdnaDriver::GetHandleFromVaddr(void* ptr, uint32_t* handle) {
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t XdnaDriver::ImportDMABuf(int dmabuf_fd, uint32_t &handle) {
+hsa_status_t XdnaDriver::ImportDMABuf(int dmabuf_fd,
+                                      core::ShareableHandle &handle) {
   drm_prime_handle import_params = {};
   import_params.handle = AMDXDNA_INVALID_BO_HANDLE;
   import_params.fd = dmabuf_fd;
   if (ioctl(fd_, DRM_IOCTL_PRIME_FD_TO_HANDLE, &import_params) < 0)
     return HSA_STATUS_ERROR;
 
-  handle = import_params.handle;
+  handle.handle = import_params.handle;
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t XdnaDriver::Map(uint32_t handle, void *va, size_t offset,
-                             size_t size, hsa_access_permission_t perms) {
+hsa_status_t XdnaDriver::Map(core::ShareableHandle handle, void *va,
+                             size_t offset, size_t size,
+                             hsa_access_permission_t perms) {
   // Get fd associated with the handle.
   drm_prime_handle params = {};
-  params.handle = handle;
+  params.handle = handle.handle;
   params.fd = -1;
   if (ioctl(fd_, DRM_IOCTL_PRIME_HANDLE_TO_FD, &params) < 0)
     return HSA_STATUS_ERROR;
@@ -315,18 +321,21 @@ hsa_status_t XdnaDriver::Map(uint32_t handle, void *va, size_t offset,
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t XdnaDriver::Unmap(uint32_t handle, void *va, size_t size) {
+hsa_status_t XdnaDriver::Unmap(core::ShareableHandle handle, void *va,
+                               size_t size) {
   if (munmap(va, size) != 0)
     return HSA_STATUS_ERROR;
 
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t XdnaDriver::ReleaseHandle(uint32_t handle) {
+hsa_status_t XdnaDriver::ReleaseShareableHandle(core::ShareableHandle &handle) {
   drm_gem_close close_params = {};
-  close_params.handle = handle;
+  close_params.handle = handle.handle;
   if (ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_params) < 0)
     return HSA_STATUS_ERROR;
+
+  handle = {};
 
   return HSA_STATUS_SUCCESS;
 }

--- a/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -286,14 +286,14 @@ hsa_status_t XdnaDriver::GetHandleFromVaddr(void* ptr, uint32_t* handle) {
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t XdnaDriver::ImportDMABuf(int dmabuf_fd, uint32_t *handle) {
+hsa_status_t XdnaDriver::ImportDMABuf(int dmabuf_fd, uint32_t &handle) {
   drm_prime_handle import_params = {};
   import_params.handle = AMDXDNA_INVALID_BO_HANDLE;
   import_params.fd = dmabuf_fd;
   if (ioctl(fd_, DRM_IOCTL_PRIME_FD_TO_HANDLE, &import_params) < 0)
     return HSA_STATUS_ERROR;
 
-  *handle = import_params.handle;
+  handle = import_params.handle;
   return HSA_STATUS_SUCCESS;
 }
 

--- a/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -297,6 +297,15 @@ hsa_status_t XdnaDriver::ImportDMABuf(int dmabuf_fd, uint32_t *handle) {
   return HSA_STATUS_SUCCESS;
 }
 
+hsa_status_t XdnaDriver::ReleaseBO(uint32_t handle) {
+  drm_gem_close close_params = {};
+  close_params.handle = handle;
+  if (ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_params) < 0)
+    return HSA_STATUS_ERROR;
+
+  return HSA_STATUS_SUCCESS;
+}
+
 hsa_status_t XdnaDriver::QueryDriverVersion() {
   amdxdna_drm_query_aie_version aie_version{0, 0};
   amdxdna_drm_get_info args{DRM_AMDXDNA_QUERY_AIE_VERSION, sizeof(aie_version),

--- a/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -297,20 +297,6 @@ hsa_status_t XdnaDriver::ImportDMABuf(int dmabuf_fd, uint32_t &handle) {
   return HSA_STATUS_SUCCESS;
 }
 
-__forceinline int mmap_perm(hsa_access_permission_t perms) {
-  switch (perms) {
-  case HSA_ACCESS_PERMISSION_RO:
-    return PROT_READ;
-  case HSA_ACCESS_PERMISSION_WO:
-    return PROT_WRITE;
-  case HSA_ACCESS_PERMISSION_RW:
-    return PROT_READ | PROT_WRITE;
-  case HSA_ACCESS_PERMISSION_NONE:
-  default:
-    return PROT_NONE;
-  }
-}
-
 hsa_status_t XdnaDriver::Map(uint32_t handle, void *va, size_t offset,
                              size_t size, hsa_access_permission_t perms) {
   // Get fd associated with the handle.

--- a/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -118,7 +118,7 @@ hsa_status_t XdnaDriver::GetAgentProperties(core::Agent &agent) const {
     return HSA_STATUS_ERROR;
   }
 
-  // Right now can only target N-1 columns so putting this 
+  // Right now can only target N-1 columns so putting this
   // here as a workaround
   aie_agent.SetNumCols(aie_metadata.cols - 1);
   aie_agent.SetNumCoreRows(aie_metadata.core.row_count);
@@ -283,6 +283,17 @@ hsa_status_t XdnaDriver::GetHandleFromVaddr(void* ptr, uint32_t* handle) {
   if (it == vmem_handle_mappings_reverse.end())
     return HSA_STATUS_ERROR_INVALID_ALLOCATION;
   *handle = it->second;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t XdnaDriver::ImportDMABuf(int dmabuf_fd, uint32_t *handle) {
+  drm_prime_handle import_params = {};
+  import_params.handle = AMDXDNA_INVALID_BO_HANDLE;
+  import_params.fd = dmabuf_fd;
+  if (ioctl(fd_, DRM_IOCTL_PRIME_FD_TO_HANDLE, &import_params) < 0)
+    return HSA_STATUS_ERROR;
+
+  *handle = import_params.handle;
   return HSA_STATUS_SUCCESS;
 }
 

--- a/runtime/hsa-runtime/core/inc/agent.h
+++ b/runtime/hsa-runtime/core/inc/agent.h
@@ -279,33 +279,25 @@ class Agent : public Checked<0xF6BC25EB17E6F917> {
   virtual const std::vector<const core::MemoryRegion*>& regions() const = 0;
 
   // @brief Maps the memory associated with the handle.
-  virtual hsa_status_t Map(void *handle, void *va, size_t offset, size_t size,
-                           int fd, hsa_access_permission_t perms) {
-    return HSA_STATUS_ERROR_INVALID_AGENT;
-  }
+  virtual hsa_status_t Map(core::ShareableHandle handle, void *va,
+                           size_t offset, size_t size, int fd,
+                           hsa_access_permission_t perms) = 0;
 
   // @brief Unmaps the memory associated with the handle.
-  virtual hsa_status_t Unmap(void *handle, void *va, size_t offset,
-                             size_t size) {
-    return HSA_STATUS_ERROR_INVALID_AGENT;
-  }
+  virtual hsa_status_t Unmap(core::ShareableHandle handle, void *va,
+                             size_t offset, size_t size) = 0;
 
   // @brief Imports memory using dma-buf.
   virtual hsa_status_t ExportDMABuf(void *va, size_t size, int *dmabuf_fd,
-                                    size_t *offset) {
-    return HSA_STATUS_ERROR_INVALID_AGENT;
-  }
+                                    size_t *offset) = 0;
 
   // @brief Imports memory using dma-buf.
-  virtual hsa_status_t ImportDMABuf(int dmabuf_fd, void *handle) {
-    return HSA_STATUS_ERROR_INVALID_AGENT;
-  }
+  virtual hsa_status_t ImportDMABuf(int dmabuf_fd,
+                                    core::ShareableHandle &handle) = 0;
 
   // @brief Releases the shareable handle.
-  virtual hsa_status_t ReleaseShareableHandle(void *handle, void *va,
-                                              size_t size) {
-    return HSA_STATUS_ERROR_INVALID_AGENT;
-  }
+  virtual hsa_status_t ReleaseShareableHandle(core::ShareableHandle &handle,
+                                              void *va, size_t size) = 0;
 
   // @details Returns the agent's instruction set architecture.
   virtual const Isa* isa() const = 0;

--- a/runtime/hsa-runtime/core/inc/agent.h
+++ b/runtime/hsa-runtime/core/inc/agent.h
@@ -2,24 +2,24 @@
 //
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
-// 
+//
 // Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
-// 
+//
 // Developed by:
-// 
+//
 //                 AMD Research and AMD HSA Software Development
-// 
+//
 //                 Advanced Micro Devices, Inc.
-// 
+//
 //                 www.amd.com
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
 // deal with the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense,
 // and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
+//
 //  - Redistributions of source code must retain the above copyright notice,
 //    this list of conditions and the following disclaimers.
 //  - Redistributions in binary form must reproduce the above copyright
@@ -29,7 +29,7 @@
 //    nor the names of its contributors may be used to endorse or promote
 //    products derived from this Software without specific prior written
 //    permission.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
@@ -277,6 +277,35 @@ class Agent : public Checked<0xF6BC25EB17E6F917> {
 
   // @brief Returns an array of regions owned by the agent.
   virtual const std::vector<const core::MemoryRegion*>& regions() const = 0;
+
+  // @brief Maps the memory associated with the handle.
+  virtual hsa_status_t Map(void *handle, void *va, size_t offset, size_t size,
+                           int fd, hsa_access_permission_t perms) {
+    return HSA_STATUS_ERROR_INVALID_AGENT;
+  }
+
+  // @brief Unmaps the memory associated with the handle.
+  virtual hsa_status_t Unmap(void *handle, void *va, size_t offset,
+                             size_t size) {
+    return HSA_STATUS_ERROR_INVALID_AGENT;
+  }
+
+  // @brief Imports memory using dma-buf.
+  virtual hsa_status_t ExportDMABuf(void *va, size_t size, int *dmabuf_fd,
+                                    size_t *offset) {
+    return HSA_STATUS_ERROR_INVALID_AGENT;
+  }
+
+  // @brief Imports memory using dma-buf.
+  virtual hsa_status_t ImportDMABuf(int dmabuf_fd, void *handle) {
+    return HSA_STATUS_ERROR_INVALID_AGENT;
+  }
+
+  // @brief Releases the shareable handle.
+  virtual hsa_status_t ReleaseShareableHandle(void *handle, void *va,
+                                              size_t size) {
+    return HSA_STATUS_ERROR_INVALID_AGENT;
+  }
 
   // @details Returns the agent's instruction set architecture.
   virtual const Isa* isa() const = 0;

--- a/runtime/hsa-runtime/core/inc/agent.h
+++ b/runtime/hsa-runtime/core/inc/agent.h
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2014-2024, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //

--- a/runtime/hsa-runtime/core/inc/amd_aie_agent.h
+++ b/runtime/hsa-runtime/core/inc/amd_aie_agent.h
@@ -51,6 +51,8 @@
 namespace rocr {
 namespace AMD {
 
+class XdnaDriver;
+
 class AieAgent : public core::Agent {
 public:
   /// @brief AIE agent constructor.
@@ -131,6 +133,9 @@ private:
   std::function<void *(size_t size, size_t align,
                        core::MemoryRegion::AllocateFlags flags)>
       system_allocator_;
+
+  /// @brief Owning driver.
+  XdnaDriver *driver_ = nullptr;
 
   const hsa_profile_t profile_ = HSA_PROFILE_BASE;
   const uint32_t min_aql_size_ = 0x40;

--- a/runtime/hsa-runtime/core/inc/amd_aie_agent.h
+++ b/runtime/hsa-runtime/core/inc/amd_aie_agent.h
@@ -86,15 +86,19 @@ public:
     return regions_;
   }
 
-  hsa_status_t Map(void *handle, void *va, size_t offset, size_t size, int fd,
-                   hsa_access_permission_t perms) override;
+  hsa_status_t Map(core::ShareableHandle handle, void *va, size_t offset,
+                   size_t size, int fd, hsa_access_permission_t perms) override;
 
-  hsa_status_t Unmap(void *handle, void *va, size_t offset,
+  hsa_status_t Unmap(core::ShareableHandle handle, void *va, size_t offset,
                      size_t size) override;
 
-  hsa_status_t ImportDMABuf(int dmabuf_fd, void *handle) override;
+  hsa_status_t ExportDMABuf(void *va, size_t size, int *dmabuf_fd,
+                            size_t *offset) override;
 
-  hsa_status_t ReleaseShareableHandle(void *handle, void *va,
+  hsa_status_t ImportDMABuf(int dmabuf_fd,
+                            core::ShareableHandle &handle) override;
+
+  hsa_status_t ReleaseShareableHandle(core::ShareableHandle &handle, void *va,
                                       size_t size) override;
 
   /// @brief Getter for the AIE system allocator.

--- a/runtime/hsa-runtime/core/inc/amd_aie_agent.h
+++ b/runtime/hsa-runtime/core/inc/amd_aie_agent.h
@@ -88,6 +88,9 @@ public:
 
   hsa_status_t ImportDMABuf(int dmabuf_fd, void *handle) override;
 
+  hsa_status_t ReleaseShareableHandle(void *handle, void *va,
+                                      size_t size) override;
+
   /// @brief Getter for the AIE system allocator.
   const std::function<void *(size_t size, size_t align,
                              core::MemoryRegion::AllocateFlags flags)> &

--- a/runtime/hsa-runtime/core/inc/amd_aie_agent.h
+++ b/runtime/hsa-runtime/core/inc/amd_aie_agent.h
@@ -86,6 +86,8 @@ public:
     return regions_;
   }
 
+  hsa_status_t ImportDMABuf(int dmabuf_fd, void *handle) override;
+
   /// @brief Getter for the AIE system allocator.
   const std::function<void *(size_t size, size_t align,
                              core::MemoryRegion::AllocateFlags flags)> &

--- a/runtime/hsa-runtime/core/inc/amd_aie_agent.h
+++ b/runtime/hsa-runtime/core/inc/amd_aie_agent.h
@@ -86,6 +86,12 @@ public:
     return regions_;
   }
 
+  hsa_status_t Map(void *handle, void *va, size_t offset, size_t size, int fd,
+                   hsa_access_permission_t perms) override;
+
+  hsa_status_t Unmap(void *handle, void *va, size_t offset,
+                     size_t size) override;
+
   hsa_status_t ImportDMABuf(int dmabuf_fd, void *handle) override;
 
   hsa_status_t ReleaseShareableHandle(void *handle, void *va,

--- a/runtime/hsa-runtime/core/inc/amd_aie_agent.h
+++ b/runtime/hsa-runtime/core/inc/amd_aie_agent.h
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2022-2023, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2022-2024, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //

--- a/runtime/hsa-runtime/core/inc/amd_cpu_agent.h
+++ b/runtime/hsa-runtime/core/inc/amd_cpu_agent.h
@@ -2,24 +2,24 @@
 //
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
-// 
+//
 // Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
-// 
+//
 // Developed by:
-// 
+//
 //                 AMD Research and AMD HSA Software Development
-// 
+//
 //                 Advanced Micro Devices, Inc.
-// 
+//
 //                 www.amd.com
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
 // deal with the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense,
 // and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
+//
 //  - Redistributions of source code must retain the above copyright notice,
 //    this list of conditions and the following disclaimers.
 //  - Redistributions in binary form must reproduce the above copyright
@@ -29,7 +29,7 @@
 //    nor the names of its contributors may be used to endorse or promote
 //    products derived from this Software without specific prior written
 //    permission.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
@@ -103,6 +103,18 @@ class CpuAgent : public core::Agent {
                            uint32_t private_segment_size,
                            uint32_t group_segment_size,
                            core::Queue** queue) override;
+
+  // @brief Override from core::Agent.
+  hsa_status_t Map(void *handle, void *va, size_t offset, size_t size, int fd,
+                   hsa_access_permission_t perms) override;
+
+  // @brief Override from core::Agent.
+  hsa_status_t Unmap(void *handle, void *va, size_t offset,
+                     size_t size) override;
+
+  // @brief Override from core::Agent.
+  hsa_status_t ReleaseShareableHandle(void *handle, void *va,
+                                      size_t size) override;
 
   // @brief Override from core::Agent.
   hsa_status_t DmaCopy(void* dst, core::Agent& dst_agent, const void* src, core::Agent& src_agent,

--- a/runtime/hsa-runtime/core/inc/amd_cpu_agent.h
+++ b/runtime/hsa-runtime/core/inc/amd_cpu_agent.h
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2014-2024, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //

--- a/runtime/hsa-runtime/core/inc/amd_cpu_agent.h
+++ b/runtime/hsa-runtime/core/inc/amd_cpu_agent.h
@@ -105,15 +105,23 @@ class CpuAgent : public core::Agent {
                            core::Queue** queue) override;
 
   // @brief Override from core::Agent.
-  hsa_status_t Map(void *handle, void *va, size_t offset, size_t size, int fd,
-                   hsa_access_permission_t perms) override;
+  hsa_status_t Map(core::ShareableHandle handle, void *va, size_t offset,
+                   size_t size, int fd, hsa_access_permission_t perms) override;
 
   // @brief Override from core::Agent.
-  hsa_status_t Unmap(void *handle, void *va, size_t offset,
+  hsa_status_t Unmap(core::ShareableHandle handle, void *va, size_t offset,
                      size_t size) override;
 
   // @brief Override from core::Agent.
-  hsa_status_t ReleaseShareableHandle(void *handle, void *va,
+  hsa_status_t ExportDMABuf(void *va, size_t size, int *dmabuf_fd,
+                            size_t *offset) override;
+
+  // @brief Override from core::Agent.
+  hsa_status_t ImportDMABuf(int dmabuf_fd,
+                            core::ShareableHandle &handle) override;
+
+  // @brief Override from core::Agent.
+  hsa_status_t ReleaseShareableHandle(core::ShareableHandle &handle, void *va,
                                       size_t size) override;
 
   // @brief Override from core::Agent.

--- a/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
+++ b/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
@@ -318,18 +318,19 @@ class GpuAgent : public GpuAgentInt {
                            uint32_t group_segment_size,
                            core::Queue** queue) override;
 
-  hsa_status_t Map(void *handle, void *va, size_t offset, size_t size, int fd,
-                   hsa_access_permission_t perms) override;
+  hsa_status_t Map(core::ShareableHandle handle, void *va, size_t offset,
+                   size_t size, int fd, hsa_access_permission_t perms) override;
 
-  hsa_status_t Unmap(void *handle, void *va, size_t offset,
+  hsa_status_t Unmap(core::ShareableHandle handle, void *va, size_t offset,
                      size_t size) override;
 
   hsa_status_t ExportDMABuf(void *va, size_t size, int *dmabuf_fd,
                             size_t *offset) override;
 
-  hsa_status_t ImportDMABuf(int dmabuf_fd, void *handle) override;
+  hsa_status_t ImportDMABuf(int dmabuf_fd,
+                            core::ShareableHandle &handle) override;
 
-  hsa_status_t ReleaseShareableHandle(void *handle, void *va,
+  hsa_status_t ReleaseShareableHandle(core::ShareableHandle &handle, void *va,
                                       size_t size) override;
 
   // @brief Decrement GWS ref count.

--- a/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
+++ b/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2014-2024, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //

--- a/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
+++ b/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
@@ -318,6 +318,20 @@ class GpuAgent : public GpuAgentInt {
                            uint32_t group_segment_size,
                            core::Queue** queue) override;
 
+  hsa_status_t Map(void *handle, void *va, size_t offset, size_t size, int fd,
+                   hsa_access_permission_t perms) override;
+
+  hsa_status_t Unmap(void *handle, void *va, size_t offset,
+                     size_t size) override;
+
+  hsa_status_t ExportDMABuf(void *va, size_t size, int *dmabuf_fd,
+                            size_t *offset) override;
+
+  hsa_status_t ImportDMABuf(int dmabuf_fd, void *handle) override;
+
+  hsa_status_t ReleaseShareableHandle(void *handle, void *va,
+                                      size_t size) override;
+
   // @brief Decrement GWS ref count.
   void GWSRelease();
 

--- a/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -101,10 +101,27 @@ public:
   /// @param[out] handle handle to the imported memory
   hsa_status_t ImportDMABuf(int dmabuf_fd, uint32_t *handle);
 
+  /// @brief Maps the memory associated with the handle.
+  ///
+  /// @param[in] handle handle to the memory object
+  /// @param[in] va virtual address associated with the handle
+  /// @param[in] offset memory offset in bytes
+  /// @param[in] size memory size in bytes
+  /// @param[perms] perms new permissions
+  hsa_status_t Map(uint32_t handle, void *va, size_t offset, size_t size,
+                   hsa_access_permission_t perms);
+
+  /// @brief Unmaps the memory associated with the handle.
+  ///
+  /// @param[in] handle handle to the memory object
+  /// @param[in] va virtual address associated with the handle
+  /// @param[in] size memory size in bytes
+  hsa_status_t Unmap(uint32_t handle, void *va, size_t size);
+
   /// @brief Releases the object associated with the handle.
   ///
-  /// @param[in] handle handle of the object to release.
-  hsa_status_t ReleaseBO(uint32_t handle);
+  /// @param[in] handle handle of the object to release
+  hsa_status_t ReleaseHandle(uint32_t handle);
 
 private:
   hsa_status_t QueryDriverVersion();

--- a/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -99,7 +99,7 @@ public:
   ///
   /// @param[in] dmabuf_fd dma-buf file descriptor
   /// @param[out] handle handle to the imported memory
-  hsa_status_t ImportDMABuf(int dmabuf_fd, uint32_t &handle);
+  hsa_status_t ImportDMABuf(int dmabuf_fd, core::ShareableHandle &handle);
 
   /// @brief Maps the memory associated with the handle.
   ///
@@ -108,20 +108,20 @@ public:
   /// @param[in] offset memory offset in bytes
   /// @param[in] size memory size in bytes
   /// @param[perms] perms new permissions
-  hsa_status_t Map(uint32_t handle, void *va, size_t offset, size_t size,
-                   hsa_access_permission_t perms);
+  hsa_status_t Map(core::ShareableHandle handle, void *va, size_t offset,
+                   size_t size, hsa_access_permission_t perms);
 
   /// @brief Unmaps the memory associated with the handle.
   ///
   /// @param[in] handle handle to the memory object
   /// @param[in] va virtual address associated with the handle
   /// @param[in] size memory size in bytes
-  hsa_status_t Unmap(uint32_t handle, void *va, size_t size);
+  hsa_status_t Unmap(core::ShareableHandle handle, void *va, size_t size);
 
   /// @brief Releases the object associated with the handle.
   ///
   /// @param[in] handle handle of the object to release
-  hsa_status_t ReleaseHandle(uint32_t handle);
+  hsa_status_t ReleaseShareableHandle(core::ShareableHandle &handle);
 
 private:
   hsa_status_t QueryDriverVersion();

--- a/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -101,6 +101,11 @@ public:
   /// @param[out] handle handle to the imported memory
   hsa_status_t ImportDMABuf(int dmabuf_fd, uint32_t *handle);
 
+  /// @brief Releases the object associated with the handle.
+  ///
+  /// @param[in] handle handle of the object to release.
+  hsa_status_t ReleaseBO(uint32_t handle);
+
 private:
   hsa_status_t QueryDriverVersion();
   /// @brief Allocate device accesible heap space.

--- a/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -95,6 +95,12 @@ public:
 
   hsa_status_t GetHandleFromVaddr(void* ptr, uint32_t* handle) override;
 
+  /// @brief Imports a memory chunk via dma-buf.
+  ///
+  /// @param[in] dmabuf_fd dma-buf file descriptor
+  /// @param[out] handle handle to the imported memory
+  hsa_status_t ImportDMABuf(int dmabuf_fd, uint32_t *handle);
+
 private:
   hsa_status_t QueryDriverVersion();
   /// @brief Allocate device accesible heap space.

--- a/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -99,7 +99,7 @@ public:
   ///
   /// @param[in] dmabuf_fd dma-buf file descriptor
   /// @param[out] handle handle to the imported memory
-  hsa_status_t ImportDMABuf(int dmabuf_fd, uint32_t *handle);
+  hsa_status_t ImportDMABuf(int dmabuf_fd, uint32_t &handle);
 
   /// @brief Maps the memory associated with the handle.
   ///

--- a/runtime/hsa-runtime/core/inc/driver.h
+++ b/runtime/hsa-runtime/core/inc/driver.h
@@ -113,7 +113,7 @@ class Driver {
 
   /// @brief Allocate agent-accessible memory (system or agent-local memory).
   ///
-  /// @param[out] pointer to newly allocated memory.
+  /// @param[out] mem pointer to newly allocated memory.
   ///
   /// @retval HSA_STATUS_SUCCESS if memory was successfully allocated or
   /// hsa_status_t error code if the memory allocation failed.

--- a/runtime/hsa-runtime/core/inc/driver.h
+++ b/runtime/hsa-runtime/core/inc/driver.h
@@ -55,6 +55,7 @@ namespace rocr {
 namespace core {
 
 class Queue;
+struct ShareableHandle;
 
 struct DriverVersionInfo {
   uint32_t major;

--- a/runtime/hsa-runtime/core/inc/driver.h
+++ b/runtime/hsa-runtime/core/inc/driver.h
@@ -45,6 +45,7 @@
 
 #include <limits>
 #include <string>
+#include <sys/mman.h>
 
 #include "core/inc/memory_region.h"
 #include "inc/hsa.h"
@@ -70,8 +71,23 @@ enum class DriverType { XDNA = 0, KFD, NUM_DRIVER_TYPES };
 /// and agent kernel drivers. It also maintains state associated with active
 /// kernel drivers.
 class Driver {
- public:
-  Driver() = delete;
+public:
+  /// @brief Converts @ref hsa_access_permission_t to mmap memory protection
+  ///        flags.
+  __forceinline static int mmap_perm(hsa_access_permission_t perms) {
+    switch (perms) {
+    case HSA_ACCESS_PERMISSION_RO:
+      return PROT_READ;
+    case HSA_ACCESS_PERMISSION_WO:
+      return PROT_WRITE;
+    case HSA_ACCESS_PERMISSION_RW:
+      return PROT_READ | PROT_WRITE;
+    case HSA_ACCESS_PERMISSION_NONE:
+    default:
+      return PROT_NONE;
+    }
+  }
+
   Driver(DriverType kernel_driver_type, std::string devnode_name);
   virtual ~Driver() = default;
 

--- a/runtime/hsa-runtime/core/inc/driver.h
+++ b/runtime/hsa-runtime/core/inc/driver.h
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2023, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2023-2024, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //

--- a/runtime/hsa-runtime/core/inc/runtime.h
+++ b/runtime/hsa-runtime/core/inc/runtime.h
@@ -816,8 +816,6 @@ class Runtime {
 
   struct MappedHandle;
   struct MappedHandleAllowedAgent {
-    MappedHandleAllowedAgent()
-        : va(NULL), permissions(HSA_ACCESS_PERMISSION_NONE), mappedHandle(NULL), ldrm_bo(0) {}
     MappedHandleAllowedAgent(MappedHandle* _mappedHandle, Agent* targetAgent, void* va, size_t size,
                              hsa_access_permission_t perms);
     ~MappedHandleAllowedAgent();
@@ -834,16 +832,6 @@ class Runtime {
   };
 
   struct MappedHandle {
-    MappedHandle()
-        : mem_handle(NULL),
-          address_handle(NULL),
-          offset(0),
-          mmap_offset(0),
-          size(0),
-          drm_fd(-1),
-          drm_cpu_addr(NULL),
-          ldrm_bo(0) {}
-
     MappedHandle(MemoryHandle* mem_handle, AddressHandle* address_handle, uint64_t offset,
                  size_t size, int drm_fd, void* drm_cpu_addr, hsa_access_permission_t perm,
                  amdgpu_bo_handle bo)

--- a/runtime/hsa-runtime/core/inc/runtime.h
+++ b/runtime/hsa-runtime/core/inc/runtime.h
@@ -787,7 +787,6 @@ class Runtime {
   std::map<const void*, AddressHandle> reserved_address_map_;  // Indexed by VA
 
   struct MemoryHandle {
-    MemoryHandle() : region(NULL), size(0), ref_count(0), thunk_handle(NULL), alloc_flag(0) {}
     MemoryHandle(const MemoryRegion* region, size_t size, uint64_t flags_unused,
                  ThunkHandle thunk_handle, MemoryRegion::AllocateFlags alloc_flag)
         : region(region),

--- a/runtime/hsa-runtime/core/inc/runtime.h
+++ b/runtime/hsa-runtime/core/inc/runtime.h
@@ -837,7 +837,6 @@ class Runtime {
         : mem_handle(mem_handle),
           address_handle(address_handle),
           offset(offset),
-          mmap_offset(0),
           size(size),
           drm_fd(drm_fd),
           drm_cpu_addr(drm_cpu_addr),
@@ -848,7 +847,6 @@ class Runtime {
     MemoryHandle* mem_handle;
     AddressHandle* address_handle;
     uint64_t offset;
-    uint64_t mmap_offset;
     size_t size;
     int drm_fd;
     void* drm_cpu_addr;  // CPU Buffer address

--- a/runtime/hsa-runtime/core/runtime/amd_aie_agent.cpp
+++ b/runtime/hsa-runtime/core/runtime/amd_aie_agent.cpp
@@ -303,6 +303,8 @@ hsa_status_t AieAgent::QueueCreate(size_t size, hsa_queue_type32_t queue_type,
 
 hsa_status_t AieAgent::Map(void *handle, void *va, size_t offset, size_t size,
                            int fd, hsa_access_permission_t perms) {
+  // fd is ignored since it corresponds to the allocated buffer, not the dma-buf export.
+  // The driver will retrieve the correct fd from the handle.
   auto &driver = static_cast<XdnaDriver &>(
       core::Runtime::runtime_singleton_->AgentDriver(driver_type));
   return driver.Map(*static_cast<uint32_t *>(handle), va, offset, size, perms);

--- a/runtime/hsa-runtime/core/runtime/amd_aie_agent.cpp
+++ b/runtime/hsa-runtime/core/runtime/amd_aie_agent.cpp
@@ -300,6 +300,12 @@ hsa_status_t AieAgent::QueueCreate(size_t size, hsa_queue_type32_t queue_type,
   return HSA_STATUS_SUCCESS;
 }
 
+hsa_status_t AieAgent::ImportDMABuf(int dmabuf_fd, void *handle) {
+  auto &driver = static_cast<XdnaDriver &>(
+      core::Runtime::runtime_singleton_->AgentDriver(driver_type));
+  return driver.ImportDMABuf(dmabuf_fd, static_cast<uint32_t *>(handle));
+}
+
 void AieAgent::InitRegionList() {
   /// TODO: Find a way to set the other memory properties in a reasonable way.
   ///       This should be easier once the ROCt source is incorporated into the

--- a/runtime/hsa-runtime/core/runtime/amd_aie_agent.cpp
+++ b/runtime/hsa-runtime/core/runtime/amd_aie_agent.cpp
@@ -310,7 +310,7 @@ hsa_status_t AieAgent::ReleaseShareableHandle(void *handle, void *va,
                                               size_t size) {
   auto &driver = static_cast<XdnaDriver &>(
       core::Runtime::runtime_singleton_->AgentDriver(driver_type));
-  return driver.ReleaseBO(*static_cast<uint32_t*>(handle));
+  return driver.ReleaseBO(*static_cast<uint32_t *>(handle));
 }
 
 void AieAgent::InitRegionList() {

--- a/runtime/hsa-runtime/core/runtime/amd_aie_agent.cpp
+++ b/runtime/hsa-runtime/core/runtime/amd_aie_agent.cpp
@@ -303,8 +303,8 @@ hsa_status_t AieAgent::QueueCreate(size_t size, hsa_queue_type32_t queue_type,
 
 hsa_status_t AieAgent::Map(void *handle, void *va, size_t offset, size_t size,
                            int fd, hsa_access_permission_t perms) {
-  // fd is ignored since it corresponds to the allocated buffer, not the dma-buf export.
-  // The driver will retrieve the correct fd from the handle.
+  // fd is ignored since it corresponds to the allocated buffer, not the dma-buf
+  // export. The driver will retrieve the correct fd from the handle.
   auto &driver = static_cast<XdnaDriver &>(
       core::Runtime::runtime_singleton_->AgentDriver(driver_type));
   return driver.Map(*static_cast<uint32_t *>(handle), va, offset, size, perms);
@@ -320,7 +320,7 @@ hsa_status_t AieAgent::Unmap(void *handle, void *va, size_t offset,
 hsa_status_t AieAgent::ImportDMABuf(int dmabuf_fd, void *handle) {
   auto &driver = static_cast<XdnaDriver &>(
       core::Runtime::runtime_singleton_->AgentDriver(driver_type));
-  return driver.ImportDMABuf(dmabuf_fd, static_cast<uint32_t *>(handle));
+  return driver.ImportDMABuf(dmabuf_fd, *static_cast<uint32_t *>(handle));
 }
 
 hsa_status_t AieAgent::ReleaseShareableHandle(void *handle, void *va,

--- a/runtime/hsa-runtime/core/runtime/amd_aie_agent.cpp
+++ b/runtime/hsa-runtime/core/runtime/amd_aie_agent.cpp
@@ -306,6 +306,13 @@ hsa_status_t AieAgent::ImportDMABuf(int dmabuf_fd, void *handle) {
   return driver.ImportDMABuf(dmabuf_fd, static_cast<uint32_t *>(handle));
 }
 
+hsa_status_t AieAgent::ReleaseShareableHandle(void *handle, void *va,
+                                              size_t size) {
+  auto &driver = static_cast<XdnaDriver &>(
+      core::Runtime::runtime_singleton_->AgentDriver(driver_type));
+  return driver.ReleaseBO(*static_cast<uint32_t*>(handle));
+}
+
 void AieAgent::InitRegionList() {
   /// TODO: Find a way to set the other memory properties in a reasonable way.
   ///       This should be easier once the ROCt source is incorporated into the

--- a/runtime/hsa-runtime/core/runtime/amd_cpu_agent.cpp
+++ b/runtime/hsa-runtime/core/runtime/amd_cpu_agent.cpp
@@ -427,19 +427,16 @@ __forceinline int mmap_perm(hsa_access_permission_t perms) {
   case HSA_ACCESS_PERMISSION_RW:
     return PROT_READ | PROT_WRITE;
   case HSA_ACCESS_PERMISSION_NONE:
-    return PROT_NONE;
   default:
-    break;
+    return PROT_NONE;
   }
-
-  return 0;
 }
 
 hsa_status_t CpuAgent::Map(void *handle, void *va, size_t offset, size_t size,
                            int fd, hsa_access_permission_t perms) {
-  void *ret_cpu_addr =
+  void *mapped_ptr =
       mmap(va, size, mmap_perm(perms), MAP_SHARED | MAP_FIXED, fd, offset);
-  if (ret_cpu_addr != va)
+  if (mapped_ptr != va)
     return HSA_STATUS_ERROR;
 
   return HSA_STATUS_SUCCESS;

--- a/runtime/hsa-runtime/core/runtime/amd_cpu_agent.cpp
+++ b/runtime/hsa-runtime/core/runtime/amd_cpu_agent.cpp
@@ -418,8 +418,9 @@ hsa_status_t CpuAgent::QueueCreate(size_t size, hsa_queue_type32_t queue_type,
   return HSA_STATUS_ERROR;
 }
 
-hsa_status_t CpuAgent::Map(void *handle, void *va, size_t offset, size_t size,
-                           int fd, hsa_access_permission_t perms) {
+hsa_status_t CpuAgent::Map(core::ShareableHandle handle, void *va,
+                           size_t offset, size_t size, int fd,
+                           hsa_access_permission_t perms) {
   void *mapped_ptr = mmap(va, size, core::Driver::mmap_perm(perms),
                           MAP_SHARED | MAP_FIXED, fd, offset);
   if (mapped_ptr != va)
@@ -428,19 +429,32 @@ hsa_status_t CpuAgent::Map(void *handle, void *va, size_t offset, size_t size,
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t CpuAgent::Unmap(void *handle, void *va, size_t offset,
-                             size_t size) {
+hsa_status_t CpuAgent::Unmap(core::ShareableHandle handle, void *va,
+                             size_t offset, size_t size) {
   if (munmap(va, size) != 0)
     return HSA_STATUS_ERROR;
 
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t CpuAgent::ReleaseShareableHandle(void *handle, void *va,
-                                              size_t size) {
+hsa_status_t CpuAgent::ExportDMABuf(void *va, size_t size, int *dmabuf_fd,
+                                    size_t *offset) {
+  // not implemented
+  return HSA_STATUS_ERROR_INVALID_AGENT;
+}
+
+hsa_status_t CpuAgent::ImportDMABuf(int dmabuf_fd,
+                                    core::ShareableHandle &handle) {
+  // not implemented
+  return HSA_STATUS_ERROR_INVALID_AGENT;
+}
+
+hsa_status_t CpuAgent::ReleaseShareableHandle(core::ShareableHandle &handle,
+                                              void *va, size_t size) {
   if (munmap(va, size) != 0)
     return HSA_STATUS_ERROR;
 
+  handle = {};
   return HSA_STATUS_SUCCESS;
 }
 

--- a/runtime/hsa-runtime/core/runtime/amd_cpu_agent.cpp
+++ b/runtime/hsa-runtime/core/runtime/amd_cpu_agent.cpp
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2014-2024, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //

--- a/runtime/hsa-runtime/core/runtime/amd_cpu_agent.cpp
+++ b/runtime/hsa-runtime/core/runtime/amd_cpu_agent.cpp
@@ -418,24 +418,10 @@ hsa_status_t CpuAgent::QueueCreate(size_t size, hsa_queue_type32_t queue_type,
   return HSA_STATUS_ERROR;
 }
 
-__forceinline int mmap_perm(hsa_access_permission_t perms) {
-  switch (perms) {
-  case HSA_ACCESS_PERMISSION_RO:
-    return PROT_READ;
-  case HSA_ACCESS_PERMISSION_WO:
-    return PROT_WRITE;
-  case HSA_ACCESS_PERMISSION_RW:
-    return PROT_READ | PROT_WRITE;
-  case HSA_ACCESS_PERMISSION_NONE:
-  default:
-    return PROT_NONE;
-  }
-}
-
 hsa_status_t CpuAgent::Map(void *handle, void *va, size_t offset, size_t size,
                            int fd, hsa_access_permission_t perms) {
-  void *mapped_ptr =
-      mmap(va, size, mmap_perm(perms), MAP_SHARED | MAP_FIXED, fd, offset);
+  void *mapped_ptr = mmap(va, size, core::Driver::mmap_perm(perms),
+                          MAP_SHARED | MAP_FIXED, fd, offset);
   if (mapped_ptr != va)
     return HSA_STATUS_ERROR;
 

--- a/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -1722,12 +1722,9 @@ __forceinline uint64_t drm_perm(hsa_access_permission_t perm) {
   case HSA_ACCESS_PERMISSION_RW:
     return AMDGPU_VM_PAGE_READABLE | AMDGPU_VM_PAGE_WRITEABLE;
   case HSA_ACCESS_PERMISSION_NONE:
-    return 0;
   default:
-    break;
+    return 0;
   }
-
-  return 0;
 }
 
 hsa_status_t GpuAgent::Map(void *handle, void *va, size_t offset, size_t size,

--- a/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2014-2023, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2014-2024, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //

--- a/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -76,8 +76,9 @@
 
 #if defined(__linux__)
 // libdrm headers
-#include <xf86drm.h>
 #include <amdgpu.h>
+#include <amdgpu_drm.h>
+#include <xf86drm.h>
 #endif
 
 
@@ -94,6 +95,9 @@ extern HsaApiTable hsa_internal_api_table_;
 
 namespace AMD {
 const uint64_t CP_DMA_DATA_TRANSFER_CNT_MAX = (1 << 26);
+
+const uint32_t GpuAgent::minAqlSize_;
+const uint32_t GpuAgent::maxAqlSize_;
 
 GpuAgent::GpuAgent(HSAuint32 node, const HsaNodeProperties& node_props, bool xnack_mode,
                    uint32_t index)
@@ -1706,6 +1710,86 @@ hsa_status_t GpuAgent::QueueCreate(size_t size, hsa_queue_type32_t queue_type,
   }
 
   scratchGuard.Dismiss();
+  return HSA_STATUS_SUCCESS;
+}
+
+__forceinline uint64_t drm_perm(hsa_access_permission_t perm) {
+  switch (perm) {
+  case HSA_ACCESS_PERMISSION_RO:
+    return AMDGPU_VM_PAGE_READABLE;
+  case HSA_ACCESS_PERMISSION_WO:
+    return AMDGPU_VM_PAGE_WRITEABLE;
+  case HSA_ACCESS_PERMISSION_RW:
+    return AMDGPU_VM_PAGE_READABLE | AMDGPU_VM_PAGE_WRITEABLE;
+  case HSA_ACCESS_PERMISSION_NONE:
+    return 0;
+  default:
+    break;
+  }
+
+  return 0;
+}
+
+hsa_status_t GpuAgent::Map(void *handle, void *va, size_t offset, size_t size,
+                           int fd, hsa_access_permission_t perms) {
+  const auto &ldrm_bo = *static_cast<amdgpu_bo_handle *>(handle);
+  if (!ldrm_bo)
+    return HSA_STATUS_ERROR;
+  if (amdgpu_bo_va_op(ldrm_bo, offset, size, reinterpret_cast<uint64_t>(va),
+                      drm_perm(perms), AMDGPU_VA_OP_MAP) != 0)
+    return HSA_STATUS_ERROR;
+
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t GpuAgent::Unmap(void *handle, void *va, size_t offset,
+                             size_t size) {
+  const auto &ldrm_bo = *static_cast<amdgpu_bo_handle *>(handle);
+  if (!ldrm_bo)
+    return HSA_STATUS_ERROR;
+
+  if (amdgpu_bo_va_op(ldrm_bo, offset, size, reinterpret_cast<uint64_t>(va), 0,
+                      AMDGPU_VA_OP_UNMAP) != 0)
+    return HSA_STATUS_ERROR;
+
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t GpuAgent::ExportDMABuf(void *va, size_t size, int *dmabuf_fd,
+                                    size_t *offset) {
+  int dmabuf_fd_res = -1;
+  size_t offset_res = 0;
+  if (hsaKmtExportDMABufHandle(va, size, &dmabuf_fd_res, &offset_res) !=
+      HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+
+  *dmabuf_fd = dmabuf_fd_res;
+  *offset = offset_res;
+
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t GpuAgent::ImportDMABuf(int dmabuf_fd, void *handle) {
+  amdgpu_bo_import_result res;
+  auto ret = amdgpu_bo_import(libDrmDev(), amdgpu_bo_handle_type_dma_buf_fd,
+                              dmabuf_fd, &res);
+  if (ret)
+    return HSA_STATUS_ERROR;
+
+  *static_cast<amdgpu_bo_handle *>(handle) = res.buf_handle;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t GpuAgent::ReleaseShareableHandle(void *handle, void *va,
+                                              size_t size) {
+  const auto &ldrm_bo = *static_cast<amdgpu_bo_handle *>(handle);
+  if (!ldrm_bo)
+    return HSA_STATUS_ERROR;
+
+  auto ret = amdgpu_bo_free(ldrm_bo);
+  if (ret)
+    return HSA_STATUS_ERROR;
+
   return HSA_STATUS_SUCCESS;
 }
 

--- a/runtime/hsa-runtime/core/runtime/amd_memory_region.cpp
+++ b/runtime/hsa-runtime/core/runtime/amd_memory_region.cpp
@@ -43,7 +43,6 @@
 #include "core/inc/amd_memory_region.h"
 
 #include <algorithm>
-#include <set>
 
 #include "core/inc/runtime.h"
 #include "core/inc/amd_cpu_agent.h"
@@ -508,7 +507,6 @@ hsa_status_t MemoryRegion::AllowAccess(uint32_t num_agents,
 
   bool cpu_in_list = false;
 
-  std::set<GpuAgentInt*> whitelist_gpus;
   std::vector<uint32_t> whitelist_nodes;
   for (uint32_t i = 0; i < num_agents; ++i) {
     core::Agent* agent = core::Agent::Convert(agents[i]);
@@ -516,11 +514,15 @@ hsa_status_t MemoryRegion::AllowAccess(uint32_t num_agents,
       return HSA_STATUS_ERROR_INVALID_AGENT;
     }
 
-    if (agent->device_type() == core::Agent::kAmdGpuDevice) {
+    switch (agent->device_type()) {
+    case core::Agent::kAmdGpuDevice:
       whitelist_nodes.push_back(agent->node_id());
-      whitelist_gpus.insert(reinterpret_cast<GpuAgentInt*>(agent));
-    } else {
+      break;
+    case core::Agent::kAmdCpuDevice:
       cpu_in_list = true;
+      break;
+    default:
+      return HSA_STATUS_ERROR_INVALID_AGENT;
     }
   }
 
@@ -538,7 +540,6 @@ hsa_status_t MemoryRegion::AllowAccess(uint32_t num_agents,
       std::find(whitelist_nodes.begin(), whitelist_nodes.end(), owner()->node_id()) ==
           whitelist_nodes.end()) {
     whitelist_nodes.push_back(owner()->node_id());
-    whitelist_gpus.insert(reinterpret_cast<GpuAgentInt*>(owner()));
   }
 
   HsaMemMapFlags map_flag = map_flag_;
@@ -584,15 +585,10 @@ hsa_status_t MemoryRegion::Lock(uint32_t num_agents, const hsa_agent_t* agents,
     return HSA_STATUS_SUCCESS;
   }
 
-  std::set<core::Agent*> whitelist_gpus;
   std::vector<HSAuint32> whitelist_nodes;
   if (num_agents == 0 || agents == NULL) {
     // Map to all GPU agents.
     whitelist_nodes = core::Runtime::runtime_singleton_->gpu_ids();
-
-    whitelist_gpus.insert(
-        core::Runtime::runtime_singleton_->gpu_agents().begin(),
-        core::Runtime::runtime_singleton_->gpu_agents().end());
   } else {
     for (uint32_t i = 0; i < num_agents; ++i) {
       core::Agent* agent = core::Agent::Convert(agents[i]);
@@ -600,9 +596,14 @@ hsa_status_t MemoryRegion::Lock(uint32_t num_agents, const hsa_agent_t* agents,
         return HSA_STATUS_ERROR_INVALID_AGENT;
       }
 
-      if (agent->device_type() == core::Agent::kAmdGpuDevice) {
+      switch (agent->device_type()) {
+      case core::Agent::kAmdGpuDevice:
         whitelist_nodes.push_back(agent->node_id());
-        whitelist_gpus.insert(agent);
+        break;
+      case core::Agent::kAmdCpuDevice:
+        break;
+      default:
+        return HSA_STATUS_ERROR_INVALID_AGENT;
       }
     }
   }

--- a/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -3413,14 +3413,14 @@ hsa_status_t Runtime::VMemorySetAccess(void* va, size_t size,
       auto agentPermsIt = mappedHandleIt.second->allowed_agents.find(targetAgent);
       if (agentPermsIt == mappedHandleIt.second->allowed_agents.end()) {
         /* Agent not previously allowed, we need a new entry */
-        mappedHandleIt.second->allowed_agents.emplace(
+        auto result = mappedHandleIt.second->allowed_agents.emplace(
             std::piecewise_construct, std::forward_as_tuple(targetAgent),
-            std::forward_as_tuple(mappedHandleIt.second, targetAgent, mappedHandleIt.first, size,
+            std::forward_as_tuple(mappedHandleIt.second, targetAgent,
+                                  mappedHandleIt.first, size,
                                   desc[i].permissions));
-
-        if (mappedHandleIt.second->allowed_agents[targetAgent].EnableAccess(desc[i].permissions) !=
-            HSA_STATUS_SUCCESS) {
-          mappedHandleIt.second->allowed_agents.erase(targetAgent);
+        auto agentIt = result.first;
+        if (agentIt->second.EnableAccess(desc[i].permissions) != HSA_STATUS_SUCCESS) {
+          mappedHandleIt.second->allowed_agents.erase(agentIt);
           return HSA_STATUS_ERROR;
         }
       } else {

--- a/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -881,9 +881,14 @@ hsa_status_t Runtime::InteropMap(uint32_t num_agents, Agent** agents,
     if (num_agents > tinyArraySize) delete[] nodes;
   });
 
-  for (uint32_t i = 0; i < num_agents; i++)
-    agents[i]->GetInfo((hsa_agent_info_t)HSA_AMD_AGENT_INFO_DRIVER_NODE_ID,
-                       &nodes[i]);
+  for (uint32_t i = 0; i < num_agents; i++) {
+    const auto &agent = *agents[i];
+    if (agent.driver_type == DriverType::XDNA)
+      return HSA_STATUS_ERROR_INVALID_AGENT;
+    agent.GetInfo(
+        static_cast<hsa_agent_info_t>(HSA_AMD_AGENT_INFO_DRIVER_NODE_ID),
+        &nodes[i]);
+  }
 
   if (hsaKmtRegisterGraphicsHandleToNodes(interop_handle, &info, num_agents,
                                           nodes) != HSAKMT_STATUS_SUCCESS)


### PR DESCRIPTION
This PR allows sharing GPU memory with AIE agents via the vmem API. Sharing via other alternatives (hsa_amd_memory_lock, hsa_amd_interop_map_buffer, hsa_amd_agents_allow_access) is not allowed and will throw an error.