### PR TITLE
Use is_always_lock_free from std::atomics in function BasicCheck file atomic_helpers.h

### DIFF
--- a/libhsakmt/tests/kfdtest/CMakeLists.txt
+++ b/libhsakmt/tests/kfdtest/CMakeLists.txt
@@ -221,14 +221,14 @@ message( STATUS "PROJECT_SOURCE_DIR:" ${PROJECT_SOURCE_DIR} )
 #  message(STATUS "${file}")
 #endforeach()
 
-
-if ( "${CMAKE_C_COMPILER_VERSION}" STRGREATER "4.8.0")
-## Add --enable-new-dtags to generate DT_RUNPATH
-set ( CMAKE_CXX_FLAGS "-std=gnu++17 -Wl,--enable-new-dtags" )
-elseif ( "${CMAKE_C_COMPILER_VERSION}" STRGREATER "7.5.0")
+if ( "${CMAKE_C_COMPILER_VERSION}" STRGREATER "7.5.0")
 ## c++17 become stable after GCC 7
 set ( CMAKE_CXX_FLAGS "-std=c++17 -Wl,--enable-new-dtags" )
+elseif ( "${CMAKE_C_COMPILER_VERSION}" STRGREATER "4.8.0")
+## Add --enable-new-dtags to generate DT_RUNPATH
+set ( CMAKE_CXX_FLAGS "-std=gnu++17 -Wl,--enable-new-dtags" )
 endif()
+
 if ( "${CMAKE_BUILD_TYPE}" STREQUAL Release )
     set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2" )
 else ()

--- a/libhsakmt/tests/kfdtest/CMakeLists.txt
+++ b/libhsakmt/tests/kfdtest/CMakeLists.txt
@@ -221,7 +221,7 @@ message( STATUS "PROJECT_SOURCE_DIR:" ${PROJECT_SOURCE_DIR} )
 #  message(STATUS "${file}")
 #endforeach()
 
-#add_definitions(-Wall -std=c++11)
+#add_definitions(-Wall -std=c++17)
 
 if ( "${CMAKE_C_COMPILER_VERSION}" STRGREATER "4.8.0")
 ## Add --enable-new-dtags to generate DT_RUNPATH

--- a/libhsakmt/tests/kfdtest/CMakeLists.txt
+++ b/libhsakmt/tests/kfdtest/CMakeLists.txt
@@ -221,11 +221,13 @@ message( STATUS "PROJECT_SOURCE_DIR:" ${PROJECT_SOURCE_DIR} )
 #  message(STATUS "${file}")
 #endforeach()
 
-#add_definitions(-Wall -std=c++17)
 
 if ( "${CMAKE_C_COMPILER_VERSION}" STRGREATER "4.8.0")
 ## Add --enable-new-dtags to generate DT_RUNPATH
 set ( CMAKE_CXX_FLAGS "-std=gnu++17 -Wl,--enable-new-dtags" )
+elseif ( "${CMAKE_C_COMPILER_VERSION}" STRGREATER "7.5.0")
+## c++17 become stable after GCC 7
+set ( CMAKE_CXX_FLAGS "-std=c++17 -Wl,--enable-new-dtags" )
 endif()
 if ( "${CMAKE_BUILD_TYPE}" STREQUAL Release )
     set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2" )

--- a/rocrtst/samples/CMakeLists.txt
+++ b/rocrtst/samples/CMakeLists.txt
@@ -179,7 +179,7 @@ add_definitions(-DLITTLEENDIAN_CPU=1)
 #
 # Linux Compiler options
 #
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fexceptions")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-math-errno")

--- a/rocrtst/samples/rocm_async/CMakeLists.txt
+++ b/rocrtst/samples/rocm_async/CMakeLists.txt
@@ -67,10 +67,10 @@ if("${tmp}" STREQUAL "debug")
 endif()
 
 if(ISDEBUG)
-  set(CMAKE_CXX_FLAGS "-std=c++11 -O0")
+  set(CMAKE_CXX_FLAGS "-std=c++17 -O0")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ggdb")
 else()
-  set(CMAKE_CXX_FLAGS "-std=c++11 -O2")
+  set(CMAKE_CXX_FLAGS "-std=c++17 -O2")
 endif()
 
 #

--- a/rocrtst/suites/test_common/CMakeLists.txt
+++ b/rocrtst/suites/test_common/CMakeLists.txt
@@ -239,7 +239,7 @@ add_definitions(-DLITTLEENDIAN_CPU=1)
 #
 # Linux Compiler options
 #
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 ")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 ")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fexceptions")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-math-errno")

--- a/runtime/cmake_modules/hsa_common.cmake
+++ b/runtime/cmake_modules/hsa_common.cmake
@@ -53,7 +53,7 @@ endif()
 
 if(UNIX)
   set(PS ":")
-  set(CMAKE_CXX_FLAGS "-Wall -std=c++11 ${EXTRA_CFLAGS}")
+  set(CMAKE_CXX_FLAGS "-Wall -std=c++17 ${EXTRA_CFLAGS}")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpic")
   if (CMAKE_COMPILER_IS_GNUCXX)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,--unresolved-symbols=ignore-in-shared-libs")

--- a/runtime/hsa-ext-finalize/CMakeLists.txt
+++ b/runtime/hsa-ext-finalize/CMakeLists.txt
@@ -102,7 +102,7 @@ if( NOT DEFINED OPEN_SOURCE_DIR )
 endif()
 
 ## ------------------------- Linux Compiler and Linker options -------------------------
-set ( CMAKE_CXX_FLAGS "-std=c++11 " )
+set ( CMAKE_CXX_FLAGS "-std=c++17 " )
 
 set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -fexceptions -fno-rtti -fvisibility=hidden -Wno-error=sign-compare -Wno-sign-compare -Wno-write-strings -Wno-deprecated-declarations -Wno-conversion-null -fno-math-errno -fno-threadsafe-statics -fmerge-all-constants -fms-extensions -Wno-error=comment -Wno-comment -Wno-error=pointer-arith -Wno-pointer-arith -fPIC" )
 

--- a/runtime/hsa-ext-image/CMakeLists.txt
+++ b/runtime/hsa-ext-image/CMakeLists.txt
@@ -61,7 +61,7 @@ set( OPEN_SOURCE_DIR ${OPEN_SOURCE_DIR} CACHE PATH "Open source root dir" FORCE 
 set(CMAKE_INSTALL_RPATH "$ORIGIN;$ORIGIN/../../lib;$ORIGIN/../../lib64;$ORIGIN/../lib64")
 
 ## ------------------------- Linux Compiler and Linker options -------------------------
-set ( CMAKE_CXX_FLAGS "-std=c++11 " )
+set ( CMAKE_CXX_FLAGS "-std=c++17 " )
 
 set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -fexceptions -fno-rtti -fvisibility=hidden -Wno-error=sign-compare -Wno-sign-compare -Wno-write-strings -Wno-deprecated-declarations -Wno-conversion-null -fno-math-errno -fno-threadsafe-statics -fmerge-all-constants -fms-extensions -Wno-error=comment -Wno-comment -Wno-error=pointer-arith -Wno-pointer-arith -fPIC" )
 

--- a/runtime/hsa-runtime-tools/CMakeLists.txt
+++ b/runtime/hsa-runtime-tools/CMakeLists.txt
@@ -75,7 +75,7 @@ set( OPEN_SOURCE_DIR ${OPEN_SOURCE_DIR} CACHE PATH "Open source root dir" FORCE 
 set(CMAKE_INSTALL_RPATH "$ORIGIN;$ORIGIN/../../lib;$ORIGIN/../../lib64;$ORIGIN/../lib64")
 
 ## ------------------------- Linux Compiler and Linker options -------------------------
-set ( CMAKE_CXX_FLAGS "-std=c++11 ")
+set ( CMAKE_CXX_FLAGS "-std=c++17 ")
 
 set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=return-type -Werror -fexceptions -fno-rtti -fvisibility=hidden -Wno-error=sign-compare -Wno-error=enum-compare -Wno-sign-compare -Wno-write-strings -Wno-deprecated-declarations -Wno-conversion-null -fno-math-errno -fno-threadsafe-statics -fmerge-all-constants -fms-extensions -Wno-error=comment -Wno-comment -Wno-error=pointer-arith -Wno-pointer-arith -fPIC" )
 

--- a/runtime/hsa-runtime/cmake_modules/hsa_common.cmake
+++ b/runtime/hsa-runtime/cmake_modules/hsa_common.cmake
@@ -51,7 +51,7 @@ if(CMAKE_SIZEOF_VOID_P EQUAL 8)
   set(ONLY64STR "64")
 endif()
 
-set(HSA_COMMON_CXX_FLAGS "-Wall" "-std=c++11")
+set(HSA_COMMON_CXX_FLAGS "-Wall" "-std=c++17")
 set(HSA_COMMON_CXX_FLAGS ${HSA_COMMON_CXX_FLAGS} "-fPIC")
 if (CMAKE_COMPILER_IS_GNUCXX)
   set(HSA_COMMON_CXX_FLAGS ${HSA_COMMON_CXX_FLAGS} "-Wl,--unresolved-symbols=ignore-in-shared-libs")

--- a/runtime/hsa-runtime/core/util/atomic_helpers.h
+++ b/runtime/hsa-runtime/core/util/atomic_helpers.h
@@ -145,14 +145,8 @@ static __forceinline void Fence(std::memory_order order=std::memory_order_seq_cs
 }
 
 template <class T>
-static __forceinline void BasicCheck(const T* ptr) {
-  constexpr bool value = __atomic_always_lock_free(sizeof(T), 0);
-  static_assert(value, "Atomic type may not be compatible with peripheral atomics.");
-};
-
-template <class T>
-static __forceinline void BasicCheck(const volatile T* ptr) {
-  constexpr bool value = __atomic_always_lock_free(sizeof(T), 0);
+static __forceinline void BasicCheck() {
+  constexpr bool value = std::atomic<T>::is_always_lock_free;
   static_assert(value, "Atomic type may not be compatible with peripheral atomics.");
 };
 
@@ -163,7 +157,7 @@ static __forceinline void BasicCheck(const volatile T* ptr) {
 template <class T>
 static __forceinline T
     Load(const T* ptr, std::memory_order order = std::memory_order_relaxed) {
-  BasicCheck<T>(ptr);
+  BasicCheck<T>();
   T ret;
   PreFence(order);
   __atomic_load(ptr, &ret, c11ToBuiltInFlags(order));
@@ -179,7 +173,7 @@ template <class T>
 static __forceinline T
     Load(const volatile T* ptr,
          std::memory_order order = std::memory_order_relaxed) {
-  BasicCheck<T>(ptr);
+  BasicCheck<T>();
   T ret;
   PreFence(order);
   __atomic_load(ptr, &ret, c11ToBuiltInFlags(order));
@@ -195,7 +189,7 @@ static __forceinline T
 template <class T>
 static __forceinline void Store(
     T* ptr, T val, std::memory_order order = std::memory_order_relaxed) {
-  BasicCheck<T>(ptr);
+  BasicCheck<T>();
   PreFence(order);
   __atomic_store(ptr, &val, c11ToBuiltInFlags(order));
   PostFence(order);
@@ -210,7 +204,7 @@ template <class T>
 static __forceinline void Store(
     volatile T* ptr, T val,
     std::memory_order order = std::memory_order_relaxed) {
-  BasicCheck<T>(ptr);
+  BasicCheck<T>();
   PreFence(order);
   __atomic_store(ptr, &val, c11ToBuiltInFlags(order));
   PostFence(order);
@@ -226,7 +220,7 @@ template <class T>
 static __forceinline T
     Cas(T* ptr, T val, T expected,
         std::memory_order order = std::memory_order_relaxed) {
-  BasicCheck<T>(ptr);
+  BasicCheck<T>();
   PreFence(order);
   __atomic_compare_exchange(ptr, &expected, &val, false, c11ToBuiltInFlags(order), __ATOMIC_RELAXED);
   PostFence(order);
@@ -243,7 +237,7 @@ template <class T>
 static __forceinline T
     Cas(volatile T* ptr, T val, T expected,
         std::memory_order order = std::memory_order_relaxed) {
-  BasicCheck<T>(ptr);
+  BasicCheck<T>();
   PreFence(order);
   __atomic_compare_exchange(ptr, &expected, &val, false, c11ToBuiltInFlags(order), __ATOMIC_RELAXED);
   PostFence(order);
@@ -259,7 +253,7 @@ template <class T>
 static __forceinline T
     Exchange(T* ptr, T val,
              std::memory_order order = std::memory_order_relaxed) {
-  BasicCheck<T>(ptr);
+  BasicCheck<T>();
   T ret;
   PreFence(order);
   __atomic_exchange(ptr, &val, &ret, c11ToBuiltInFlags(order));
@@ -276,7 +270,7 @@ template <class T>
 static __forceinline T
     Exchange(volatile T* ptr, T val,
              std::memory_order order = std::memory_order_relaxed) {
-  BasicCheck<T>(ptr);
+  BasicCheck<T>();
   T ret;
   PreFence(order);
   __atomic_exchange(ptr, &val, &ret, c11ToBuiltInFlags(order));
@@ -292,7 +286,7 @@ static __forceinline T
 template <class T>
 static __forceinline T
     Add(T* ptr, T val, std::memory_order order = std::memory_order_relaxed) {
-  BasicCheck<T>(ptr);
+  BasicCheck<T>();
   PreFence(order);
   T ret = __atomic_fetch_add(ptr, val, c11ToBuiltInFlags(order));
   PostFence(order);
@@ -308,7 +302,7 @@ static __forceinline T
 template <class T>
 static __forceinline T
     Sub(T* ptr, T val, std::memory_order order = std::memory_order_relaxed) {
-  BasicCheck<T>(ptr);
+  BasicCheck<T>();
   PreFence(order);
   T ret = __atomic_fetch_sub(ptr, val, c11ToBuiltInFlags(order));
   PostFence(order);
@@ -324,7 +318,7 @@ static __forceinline T
 template <class T>
 static __forceinline T
     And(T* ptr, T val, std::memory_order order = std::memory_order_relaxed) {
-  BasicCheck<T>(ptr);
+  BasicCheck<T>();
   PreFence(order);
   T ret = __atomic_fetch_and(ptr, val, c11ToBuiltInFlags(order));
   PostFence(order);
@@ -339,7 +333,7 @@ static __forceinline T
 template <class T>
 static __forceinline T
     Or(T* ptr, T val, std::memory_order order = std::memory_order_relaxed) {
-  BasicCheck<T>(ptr);
+  BasicCheck<T>();
   PreFence(order);
   T ret = __atomic_fetch_or(ptr, val, c11ToBuiltInFlags(order));
   PostFence(order);
@@ -355,7 +349,7 @@ static __forceinline T
 template <class T>
 static __forceinline T
     Xor(T* ptr, T val, std::memory_order order = std::memory_order_relaxed) {
-  BasicCheck<T>(ptr);
+  BasicCheck<T>();
   PreFence(order);
   T ret = __atomic_fetch_xor(ptr, val, c11ToBuiltInFlags(order));
   PostFence(order);
@@ -370,7 +364,7 @@ static __forceinline T
 template <class T>
 static __forceinline T
     Increment(T* ptr, std::memory_order order = std::memory_order_relaxed) {
-  BasicCheck<T>(ptr);
+  BasicCheck<T>();
   PreFence(order);
   T ret = __atomic_fetch_add(ptr, 1, c11ToBuiltInFlags(order));
   PostFence(order);
@@ -385,7 +379,7 @@ static __forceinline T
 template <class T>
 static __forceinline T
     Decrement(T* ptr, std::memory_order order = std::memory_order_relaxed) {
-  BasicCheck<T>(ptr);
+  BasicCheck<T>();
   PreFence(order);
   T ret = __atomic_fetch_sub(ptr, 1, c11ToBuiltInFlags(order));
   PostFence(order);
@@ -401,7 +395,7 @@ template <class T>
 static __forceinline T
     Add(volatile T* ptr, T val,
         std::memory_order order = std::memory_order_relaxed) {
-  BasicCheck<T>(ptr);
+  BasicCheck<T>();
   PreFence(order);
   T ret = __atomic_fetch_add(ptr, val, c11ToBuiltInFlags(order));
   PostFence(order);
@@ -418,7 +412,7 @@ template <class T>
 static __forceinline T
     Sub(volatile T* ptr, T val,
         std::memory_order order = std::memory_order_relaxed) {
-  BasicCheck<T>(ptr);
+  BasicCheck<T>();
   PreFence(order);
   T ret = __atomic_fetch_sub(ptr, val, c11ToBuiltInFlags(order));
   PostFence(order);
@@ -435,7 +429,7 @@ template <class T>
 static __forceinline T
     And(volatile T* ptr, T val,
         std::memory_order order = std::memory_order_relaxed) {
-  BasicCheck<T>(ptr);
+  BasicCheck<T>();
   PreFence(order);
   T ret = __atomic_fetch_and(ptr, val, c11ToBuiltInFlags(order));
   PostFence(order);
@@ -450,7 +444,7 @@ static __forceinline T
 template <class T>
 static __forceinline T Or(volatile T* ptr, T val,
                           std::memory_order order = std::memory_order_relaxed) {
-  BasicCheck<T>(ptr);
+  BasicCheck<T>();
   PreFence(order);
   T ret = __atomic_fetch_or(ptr, val, c11ToBuiltInFlags(order));
   PostFence(order);
@@ -467,7 +461,7 @@ template <class T>
 static __forceinline T
     Xor(volatile T* ptr, T val,
         std::memory_order order = std::memory_order_relaxed) {
-  BasicCheck<T>(ptr);
+  BasicCheck<T>();
   PreFence(order);
   T ret = __atomic_fetch_xor(ptr, val, c11ToBuiltInFlags(order));
   PostFence(order);
@@ -483,7 +477,7 @@ template <class T>
 static __forceinline T
     Increment(volatile T* ptr,
               std::memory_order order = std::memory_order_relaxed) {
-  BasicCheck<T>(ptr);
+  BasicCheck<T>();
   PreFence(order);
   T ret = __atomic_fetch_add(ptr, 1, c11ToBuiltInFlags(order));
   PostFence(order);
@@ -499,7 +493,7 @@ template <class T>
 static __forceinline T
     Decrement(volatile T* ptr,
               std::memory_order order = std::memory_order_relaxed) {
-  BasicCheck<T>(ptr);
+  BasicCheck<T>();
   PreFence(order);
   T ret = __atomic_fetch_sub(ptr, 1, c11ToBuiltInFlags(order));
   PostFence(order);

--- a/runtime/hsa-runtime/core/util/atomic_helpers.h
+++ b/runtime/hsa-runtime/core/util/atomic_helpers.h
@@ -41,7 +41,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 /*
-  Helpers to use native types with C++11 atomic operations.
+  Helpers to use native types with C++17 atomic operations.
   Fixes GCC builtin functionality for x86 with respect to WC and non-temporal
   stores.
 */


### PR DESCRIPTION
What has been changed:
1) Remove an input parameter which function BasicCheck never uses
2) Replace a Linux specific function "__atomic_always_lock_free" with std::atomic constant "is_always_lock_free" added in c++17
3) Change compiling flags from -std=c++11 to -std=c++17